### PR TITLE
Add DKPro and DKPro TC

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -220,6 +220,8 @@ Machine Learning
 -------------------
 - `BIDData <https://github.com/BIDData>`_ BIDMat is a matrix library intended to support large-scale exploratory data analysis. Its sister library BIDMach implements the machine learning layer.
 
+- `DKPro TC <https://dkpro.github.io/dkpro-tc/>`_ A UIMA-based text classification framework. Facilitates supervised machine learning experiments with any kind of textual data.
+
 - `libFM: Factorization Machine Library <http://libfm.org/>`_
 
 - `sofia-ml <https://code.google.com/p/sofia-ml/>`_ Fast incremental learning
@@ -262,6 +264,7 @@ Natural Language Processing
 ----------------------------
 
 - `BLLIP reranking parser <https://github.com/BLLIP/bllip-parser>`_ "BLLIP Parser is a statistical natural language parser including a generative constituent parser (first-stage) and discriminative maximum entropy reranker (second-stage)."
+- `DKPro <https://dkpro.github.io/>`_ A collection of re-usable NLP tools for linguistic pre-processing, machine learning, lexical resources, etc.
 - `OpenNLP <http://opennlp.apache.org/>`_ The Apache OpenNLP library is a machine learning based toolkit for the processing of natural language text.
 - `SEAL <https://github.com/TeamCohen/SEAL>`_ Set expander for any language described in this `paper <http://www.cs.cmu.edu/~wcohen/postscript/icdm-2007.pdf>`_
 - `Stanford CoreNLP <http://nlp.stanford.edu/software/corenlp.shtml>`_ "Stanford CoreNLP provides a set of natural language analysis tools written in Java"


### PR DESCRIPTION
Consider adding [DKPro](https://dkpro.github.io) to the catch-all "Natural Language Processing" section.  It's a popular, freely licensed, community-authored collection of (mostly Java) libraries and other resources for NLP.  One of the DKPro projects, DKPro TC, would also fit nicely in the "Machine Learning" section.

I should disclose that I am one of the 30-odd DKPro developers.  However, I believe the project is widely used outside its development community. The papers describing DKPro have [over 200 citations in scientific literature](https://scholar.google.co.uk/scholar?q=allintitle%3A+dkpro+OR+uby+OR+csniper+OR+jweb1t+OR+jwktl+OR+jwpl&btnG=&hl=en&as_sdt=0%2C5).
