### PR TITLE
Add Parselmouth

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -174,6 +174,7 @@ Signal Processing
 - `An Interactive Source Separation Editor <http://isse.sourceforge.net/>`_ "ISSE is an open-source, freely available, cross-platform audio editing tool that allows a user to perform source separation by painting on time-frequency visualisations of sound."
 - `Bob <https://github.com/idiap/bob>`_ Bob is a free signal-processing and machine learning toolbox originally developed by the Biometrics group at Idiap Research Institute, in Switzerland. 
 - `Matlab Audio Processing Examples <http://www.ee.columbia.edu/~dpwe/resources/matlab/>`_
+- `Parselmouth <https://github.com/YannickJadoul/Parselmouth>`_ Parselmouth is a Python interface to the `Praat <http://www.praat.org>`_ phonetics and speech analysis, synthesis, and manipulation software.
 - `SAcC - Subband Autocorrelation Classification Pitch Tracker <http://labrosa.ee.columbia.edu/projects/SAcC/>`_  "SAcC is a (compiled) Matlab script that performs noise- robust pitch tracking by classifying the autocorrelations of a set of subbands using an MLP neural network."
 
 Text-to-Speech


### PR DESCRIPTION
As described, Parselmouth is a Python interface to the widely-used scientific Praat software (cfr. [Google Scholar's list of Praat citations](https://scholar.google.com/scholar?cites=8104635033638065008&as_sdt=2005&sciodt=0,5&hl=en)).

Not entirely sure this is the correct section/category, but I think it fits best under "Signal Processing" ?